### PR TITLE
Avoid using pow to get rounding_factor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,35 +8,20 @@ commands:
       - run: bundle exec rspec
 
 jobs:
-  test-ruby-233:
-    docker:
-      - image: circleci/ruby:2.3.3
-    steps:
-      - bundle_install_and_test
-
-  test-ruby-246:
-    docker:
-      - image: circleci/ruby:2.4.6
-    steps:
-      - bundle_install_and_test
-
-  test-ruby-255:
-    docker:
-      - image: circleci/ruby:2.5.5
-    steps:
-      - bundle_install_and_test
-
   test-ruby-263:
     docker:
       - image: circleci/ruby:2.6.3
+    steps:
+      - bundle_install_and_test
+  test-ruby-271:
+    docker:
+      - image: circleci/ruby:2.7.1
     steps:
       - bundle_install_and_test
 
 workflows:
   rc:
     jobs:
-      - test-ruby-233
-      - test-ruby-246
-      - test-ruby-255
       - test-ruby-263
+      - test-ruby-271
 

--- a/ae_fast_decimal_formatter.gemspec
+++ b/ae_fast_decimal_formatter.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
     'ext/ae_fast_decimal_formatter/extconf.rb'
   ]
   s.homepage    = 'https://www.github.com/appfolio/ae_fast_decimal_formatter'
-  s.required_ruby_version = ['>= 2.3.3', '< 2.7']
+  s.required_ruby_version = ['>= 2.6.3', '< 3']
   s.licenses    = ['MIT']
   s.metadata['allowed_push_host'] = 'https://rubygems.org'
   s.extensions = %w[ext/ae_fast_decimal_formatter/extconf.rb]

--- a/ext/ae_fast_decimal_formatter/ae_fast_decimal_formatter.c
+++ b/ext/ae_fast_decimal_formatter/ae_fast_decimal_formatter.c
@@ -18,8 +18,13 @@ VALUE c_format_decimal(double num, int precision)
   formatstr[9] = 0;
 
   if (precision > 0) {
-    rounding_factor = pow(10.0, precision);
-    rounded_num = round(num * rounding_factor) / rounding_factor;
+    rounding_factor = (double) 10.0;
+    for (i = 1; i < precision; i++) { rounding_factor *= (double) 10.0; }
+
+    double multiplied_num = num * (double) 10.0;
+    for (i = 1; i < precision; i++) { multiplied_num *= (double) 10.0; }
+
+    rounded_num = round(multiplied_num) / rounding_factor;
   } else {
     rounded_num = round(num);
   }

--- a/spec/ae_fast_decimal_formatter_spec.rb
+++ b/spec/ae_fast_decimal_formatter_spec.rb
@@ -14,6 +14,10 @@ describe 'AeFastDecimalFormatter' do
       expect(ae_fast_decimal_formatter(355.785, 2)).to eq('355.79')
     end
 
+    it 'small number with rounding up at tricky value - take 2' do
+      expect(ae_fast_decimal_formatter(148.855, 2)).to eq('148.86')
+    end
+
     it 'small number with rounding down at tricky value' do
       expect(ae_fast_decimal_formatter(355.784, 2)).to eq('355.78')
     end
@@ -25,11 +29,19 @@ describe 'AeFastDecimalFormatter' do
     it 'large number without rounding' do
       expect(ae_fast_decimal_formatter(1234567890.12, 2)).to eq('1,234,567,890.12')
     end
+
+    it 'precision is 1' do
+      expect(ae_fast_decimal_formatter(355.784, 1)).to eq('355.8')
+    end
   end
 
   describe 'Precision is 0' do
     it 'small number' do
       expect(ae_fast_decimal_formatter(2.556, 0)).to eq('3')
+    end
+
+    it 'tricky case 1' do
+      expect(ae_fast_decimal_formatter(14885.5, 0)).to eq('14,886')
     end
 
     it 'large number' do
@@ -48,8 +60,30 @@ describe 'AeFastDecimalFormatter' do
       expect(ae_fast_decimal_formatter(-2.556, 2)).to eq('-2.56')
     end
 
+    it 'tricky number 1' do
+      expect(ae_fast_decimal_formatter(-1.444444, 2)).to eq('-1.44')
+    end
+
     it 'large number' do
       expect(ae_fast_decimal_formatter(-1234567890.12, 2)).to eq('-1,234,567,890.12')
+    end
+  end
+
+  describe 'zero' do
+    it 'pure zero' do
+      expect(ae_fast_decimal_formatter(0, 0)).to eq('0')
+    end
+
+    it 'negative zero' do
+      expect(ae_fast_decimal_formatter(-0, 0)).to eq('0')
+    end
+
+    it 'zero with decimal' do
+      expect(ae_fast_decimal_formatter(0.000, 0)).to eq('0')
+    end
+
+    it 'zero with small positive decimal' do
+      expect(ae_fast_decimal_formatter(0.01, 0)).to eq('0')
     end
   end
 end


### PR DESCRIPTION
Somehow using pow to get rounding factor creates failed corner case with input num = 148.855 and precision = 2. In reality we round to 2 decimal places most of the time so the loop here is not too inefficient. But this solves the corner case.