### PR TITLE
Add Backstage catalog metadata file(s)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  title: ae_fast_decimal_formatter
+  description: Formats decimals, quickly. Probably not necessary anymore.
+  tags:
+    - oss
+  annotations:
+    appfolio.com/package-location: url:https://rubygems.org/gems/ae_fast_decimal_formatter
+    appfolio.com/package-type: gem
+  name: ae-fast-decimal-formatter
+spec:
+  type: library
+  lifecycle: maintenance
+  owner: bundle-bundle-bundle


### PR DESCRIPTION
All Backstage component, resource, and api catalog metadata files are migrating to project repositories to lower the rate of effort for catalog maintenance.

[_Created by Sourcegraph batch change `modethirteen/migrate-developer-portal-catalog-open-source-metadata`._](https://sourcegraph.appf.io/users/modethirteen/batch-changes/migrate-developer-portal-catalog-open-source-metadata)