### PR TITLE
ci: scope release workflow to gem-shipped files via paths filter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - master
+    paths:
+      - 'lib/**'
+      - 'ext/**'
+      - 'ae_fast_decimal_formatter.gemspec'
+      - 'LICENSE.txt'
 
 permissions:
   contents: write

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,13 +8,7 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false,
-      "include-paths": [
-        "lib/",
-        "ext/",
-        "ae_fast_decimal_formatter.gemspec",
-        "LICENSE.txt"
-      ]
+      "prerelease": false
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary
- Adds `paths:` filter to the release workflow so it only runs when gem-shipped files change (`lib/`, `ext/`, gemspec, `LICENSE.txt`)
- Removes ineffective `include-paths` from release-please-config.json (it only applies to monorepo package routing, not release triggering)

## Test plan
- Verify that CI-only or test-only commits to master no longer trigger the Release Gem workflow