### PR TITLE
[BANK-2106] Migrate gem source from RubyGems to JFrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   gem-tool: appfolio/gem-tool@volatile
+  public-packages: https://raw.githubusercontent.com/appfolio/public-packages/v1/orbs/public-packages.yml
 
 workflows:
   rc:
@@ -15,6 +16,8 @@ workflows:
                 - '4.0.1'
                 - '3.4.8'
                 - '3.3.10'
+          after-checkout-steps:
+            - public-packages/setup
           after-appraisal-install-steps:
             - run:
                 name: Compile Extension

--- a/Appraisals
+++ b/Appraisals
@@ -2,17 +2,17 @@
 
 if Gem::Requirement.new(['>= 3.3', '< 4.1']).satisfied_by?(Gem::Version.new(RUBY_VERSION))
   appraise "ruby-#{RUBY_VERSION}__actionview_72" do
-    source 'https://rubygems.org' do
+    source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_fast_decimal_formatter-gem/' do
       gem 'actionview', '~> 7.2.0'
     end
   end
   appraise "ruby-#{RUBY_VERSION}__actionview_80" do
-    source 'https://rubygems.org' do
+    source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_fast_decimal_formatter-gem/' do
       gem 'actionview', '~> 8.0.0'
     end
   end
   appraise "ruby-#{RUBY_VERSION}__actionview_81" do
-    source 'https://rubygems.org' do
+    source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_fast_decimal_formatter-gem/' do
       gem 'actionview', '~> 8.1.0'
     end
   end

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org' # global source
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_fast_decimal_formatter-gem/'
 
-source 'https://rubygems.org' do
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_fast_decimal_formatter-gem/' do
   gem 'actionview', '>= 7.2', '< 8.2'
   gem 'activesupport', '>= 7.2', '< 8.2'
   gem 'appraisal', '>= 2.5', '< 3'

--- a/ae_fast_decimal_formatter.gemspec
+++ b/ae_fast_decimal_formatter.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
   spec.extensions            = ['ext/ae_fast_decimal_formatter/extconf.rb']
 
   spec.required_ruby_version = Gem::Requirement.new('< 4.1')
-  spec.metadata['allowed_push_host'] = 'https://rubygems.org'
+  spec.metadata['allowed_push_host'] = 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_fast_decimal_formatter-gem/'
 end

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   tags:
     - oss
   annotations:
-    appfolio.com/package-location: url:https://rubygems.org/gems/ae_fast_decimal_formatter
+    appfolio.com/package-location: url:https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_fast_decimal_formatter-gem/
     appfolio.com/package-type: gem
   name: ae-fast-decimal-formatter
 spec:


### PR DESCRIPTION
## Summary
Migrate Ruby gem source from rubygems.org to JFrog as part of org-wide JFrog migration.

## Changes
- Replaced `source 'https://rubygems.org'` with JFrog URL in Gemfile
- Replaced `source 'https://rubygems.org'` with JFrog URL in Appraisals
- Added `public-packages` orb and `after-checkout-steps` to CircleCI config
- Updated `allowed_push_host` in gemspec to JFrog URL
- Updated `package-location` in catalog-info.yaml to JFrog URL
- Created `.github/dependabot.yaml` with JFrog registry configuration

## Why
AppFolio is migrating from RubyGems.org to JFrog for Ruby dependency installation.
Jira Issue: https://appfolio.atlassian.net/browse/BANK-2106

## Test Plan
- CI passes with the new gem source configuration